### PR TITLE
Add set CO2 range to example ErriezMHZ19B7SegmentDisplay.ino

### DIFF
--- a/examples/ErriezMHZ19B7SegmentDisplay/ErriezMHZ19B7SegmentDisplay.ino
+++ b/examples/ErriezMHZ19B7SegmentDisplay/ErriezMHZ19B7SegmentDisplay.ino
@@ -139,6 +139,11 @@ void setup()
     mhz19b.getVersion(firmwareVersion, sizeof(firmwareVersion));
     Serial.println(firmwareVersion);
 
+    // Optional: Set CO2 range 2000ppm or 5000ppm (default) once
+    // Serial.print(F("Set range..."));
+    // mhz19b.setRange2000ppm();
+    // mhz19b.setRange5000ppm();
+
     // Print operating range
     Serial.print(F("  Range: "));
     Serial.print(mhz19b.getRange());


### PR DESCRIPTION
## Description and Impact
Describe your proposed Pull Request and it's impact:
This pull request adds `setRange2000ppm()` and `setRange5000ppm()` to example `ErriezMHZ19B7SegmentDisplay.ino`.
Source code is commented out by default and has no impact.

## Link to other issues
Provide relevant links to related issues, PRs etc: Not applicable.

## Tested version
Which version was used to test this pull request? 
- Branch: master
- Hash: 1824eda8927f43dad65df92a387d4cc51f43504a

Thanks for your contribution!
